### PR TITLE
Make the runtime upstream config more flexible by injecting arguments

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -68,6 +68,10 @@ defmodule ReverseProxyPlug do
 
   defp get_applied_fn(upstream, default \\ "")
 
+  defp get_applied_fn({func, param}, _) when is_function(func) do
+    func.(param)
+  end
+
   defp get_applied_fn(upstream, _) when is_function(upstream) do
     upstream.()
   end

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -312,11 +312,11 @@ defmodule ReverseProxyPlugTest do
     assert url == "http://example.com:80/"
   end
 
-  test_stream_and_buffer "allow upstream configured at runtime" do
+  test_stream_and_buffer "allow upstream configured at runtime via 0 arity function" do
     %{opts: opts, get_responder: get_responder} = test_reuse_opts
 
     opts_with_upstream =
-      Keyword.merge(opts, upstream: fn -> "//runtime.com/root_upstream?query=yes" end)
+      Keyword.merge(opts, upstream: fn -> "//runtime.com/root_upstream" end)
 
     ReverseProxyPlug.HTTPClientMock
     |> expect(:request, fn %HTTPoison.Request{url: url} = request ->
@@ -328,7 +328,26 @@ defmodule ReverseProxyPlugTest do
     |> ReverseProxyPlug.call(ReverseProxyPlug.init(opts_with_upstream))
 
     assert_receive {:url, url}
-    assert url == "http://runtime.com:80/root_upstream/root_path?query=yes"
+    assert url == "http://runtime.com:80/root_upstream/root_path"
+  end
+
+  test_stream_and_buffer "allow upstream configured at runtime via {func, param} tuple" do
+    %{opts: opts, get_responder: get_responder} = test_reuse_opts
+
+    opts_with_upstream =
+      Keyword.merge(opts, upstream: {fn x -> "//runtime.com" <> x end, "/root_upstream"})
+
+    ReverseProxyPlug.HTTPClientMock
+    |> expect(:request, fn %HTTPClient.Request{url: url} = request ->
+      send(self(), {:url, url})
+      get_responder.(%{}).(request)
+    end)
+
+    conn(:get, "/root_path")
+    |> ReverseProxyPlug.call(ReverseProxyPlug.init(opts_with_upstream))
+
+    assert_receive {:url, url}
+    assert url == "http://runtime.com:80/root_upstream/root_path"
   end
 
   test_stream_and_buffer "include the port in the host header when is not the default and preserve_host_header is false in opts" do


### PR DESCRIPTION
My use-case for this is that I want to configure my upstream hosts for different environments. In order to do this I need to combine a runtime config value with the compile time path component. 

Unfortunately we cannot use an anonymous function as plug assigns these options to a module attribute which doesn't allow anonymous functions. So this doesn't work.
```
forward("/foo", to: ReverseProxyPlug, upstream: fn -> Config.base_url() <> "/bar" end)
```

Here's the error:
```
** (ArgumentError) cannot inject attribute @plug_forward_opts into function/macro because cannot escape #Function<0.50684765 in file:lib/router.ex>. The supported values are: lists, tuples, maps, atoms, numbers, bitstrings, PIDs and remote functions in the format &Mod.fun/arity
```

So, instead we can use a two element tuple containing the `&Mod.fun/arity` style syntax and args you want passed at runtime. 

Example:
```
forward("/foo", to: ReverseProxyPlug, upstream: {&Config.base_url/1, "/bar"})
```

